### PR TITLE
Encode comma in signature generator

### DIFF
--- a/lib/bca.js
+++ b/lib/bca.js
@@ -126,7 +126,7 @@ class BCA {
     const sha256 = crypto.createHash('sha256');
     const sha256Body = sha256.update(body.replace(/\s/g, ''));
     const digestedBody = sha256Body.digest('hex');
-    const signature = hmac.update(`${method}:${encodeURI(relativeUrl)}:${accessToken}:${digestedBody}:${timestamp}`);
+    const signature = hmac.update(`${method}:${encodeURI(relativeUrl).replace(/,/g,'%2C')}:${accessToken}:${digestedBody}:${timestamp}`);
     return signature.digest('hex');
   }
 


### PR DESCRIPTION
Encode comma in uri when generating signature, used for getBalance with more than one account number (case in UAT with BCA)